### PR TITLE
print outfile name when generated

### DIFF
--- a/btr/utilities.py
+++ b/btr/utilities.py
@@ -41,6 +41,7 @@ def get_outfile_name(gmt=None):
     else:
         outfile_name = str(uuid.uuid4())
     outfile_name = outfile_name + '.csv'
+    print('outfile name: ' + outfile_name)
     return outfile_name
 
 


### PR DESCRIPTION
- this helps with debugging jobs on the cluster as job names are not mapped
  to file names normally