### PR TITLE
Check the values produced by scoring in commandline tests

### DIFF
--- a/btr/tests/test_commandline.py
+++ b/btr/tests/test_commandline.py
@@ -1,4 +1,7 @@
 from subprocess import run, PIPE, STDOUT
+from btr.loader import Loader
+from btr.utilities import get_outdir_path
+import pandas as pd
 
 settings_files = [
     'test_data/run_settings/settings_synthetic_Ordinal.json',
@@ -27,3 +30,27 @@ def test_score_synthetic():
         assert s.returncode == 0
 
 
+def test_score_values_synthetic():
+    for s in settings_files:
+        loader = Loader(settings_path=s,
+                        syn_settings_overwrite=False,
+                        use_synapse=False)
+        folder = get_outdir_path(loader.s)
+        score_csv = folder + 'score/synthetic_auc.csv'
+        df = pd.read_csv(score_csv)
+        df_dict = df.to_dict('records')[0]
+        assert df_dict['ABCeasy_cols.txt'] >= 0
+        assert df_dict['ABCeasy_cols.txt'] <= 1
+        assert df_dict['ABCeasy_cols.txt'] > 0.95
+        assert df_dict['ABChard_cols.txt'] >= 0
+        assert df_dict['ABChard_cols.txt'] <= 1
+        assert df_dict['ABChard_cols.txt'] > 0.95
+        assert df_dict['BACeasy_cols.txt'] >= 0
+        assert df_dict['BACeasy_cols.txt'] <= 1
+        assert df_dict['BACeasy_cols.txt'] > 0.95
+        assert df_dict['NS_cols.txt'] >= 0
+        assert df_dict['NS_cols.txt'] <= 1
+        assert df_dict['NS_cols.txt'] < df_dict['ABCeasy_cols.txt']
+        assert df_dict['NS_cols.txt'] < df_dict['ABChard_cols.txt']
+        assert df_dict['NS_cols.txt'] < df_dict['BACeasy_cols.txt']
+        assert df_dict['NS_cols.txt'] < 0.6


### PR DESCRIPTION
- assert that each of the 3 column sets that are predictive produce predictions
  above 0.95 (very high, should be "fixed" with noisier synthetic data)
- assert that non-sense column set isn't more predictive than any of the sense sets,
  or much better than random at 0.6 AUC
- sanity check: AUC for all should be between 0 and 1