### PR TITLE
set `skipget=True` in `save_prediction_to_synapse()`

### DIFF
--- a/btr/loader.py
+++ b/btr/loader.py
@@ -84,7 +84,7 @@ class Loader(object):
             annotations['gmt'] = gmt.suffix
         file.annotations = annotations
         file = get_or_create_syn_entity(file, self._syn,
-                                        skipget=False,
+                                        skipget=True,
                                         returnid=False)
 
 


### PR DESCRIPTION
- always write newest version of predictions to synapse
- otherwise, it's as if predictions weren't carried out, since score and stats pull from
  synapse to enforce consistency