### PR TITLE
Add RidgeClassifier

### DIFF
--- a/btr/estimators.py
+++ b/btr/estimators.py
@@ -1,6 +1,7 @@
 from mord import LogisticAT
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import LogisticRegression
+from sklearn.linear_model import RidgeClassifier
 from xgboost import XGBClassifier
 
 
@@ -18,5 +19,17 @@ def get_estimator(settings):
         return RandomForestClassifier(**params)
     elif name in ["xgboost.XGBClassifier"]:
         return XGBClassifier(**params)
+    elif name in ["sklearn.linear_model.RidgeClassifier"]:
+        return RidgeClassifierBTR(**params)
     else:
         raise NotImplementedError
+
+class RidgeClassifierBTR(RidgeClassifier):
+    def __init__(self):
+        super().__init__()
+    def predict_proba(self, X_test):
+        """Returns the distance from the hyperplane of the RidgeClassifer.
+        Not a probability, per se, but values are still rankable for LPOCV.
+        """
+        probas = self.decision_function(X_test)
+        return probas


### PR DESCRIPTION
Added RidgeClassifier from sklearn and extended it to return distance
from the hyperplane via `clf.decision_function()`. Although this is not
the same as probabilities returned by other classifiers, it does provide
rankable outputs compatible with LPOCV.